### PR TITLE
Migrate /2/sites/{id} to OpenAPI 3.0 and mark as supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Package is in active development
 | /2/times                              | List or Create Times                        |    [x]    |
 | /2/times/{id}                         | Get, Update, or Delete a single time by ID  |    [x]    |
 | /2/sites                              | List or Create Sites                        |    [x]    |
-| /2/sites/{id}                         | Get, Update, or Delete Site                 |    [ ]    |
+| /2/sites/{id}                         | Get, Update, or Delete Site                 |    [x]    |
 | /2/shifts/bulk                        | Bulk Update Shifts                          |    [ ]    |
 | /2/shifts/eligible                    | List eligible users for OpenShift           |    [ ]    |
 | /2/shifts/notify                      | Notify shifts                               |    [ ]    |

--- a/api-migration-tasks.md
+++ b/api-migration-tasks.md
@@ -5,13 +5,17 @@ This document tracks the migration of all API routes from `spec/original-spec.js
 **Instructions:**
 
 - Each API route is listed below. For each route:
-  1. Migrate the route to `apispec.yml` (ensure OpenAPI 3.0.0 compliance).
-  2. Migrate all referenced schemas (e.g., request/response bodies) to `apispec.yml`.
-  3. Ensure the new route has a default response.
-  4. Use multi-line YAML for any multi-line text fields (see example in this file).
-  5. Run `task generate` to verify the code generator works (no errors).
-  6. Mark the task as complete in this table.
-  7. Update the main [readme](README.md) for supported APIs
+
+  1. Create a new branch using feat/<apislug>
+  2. Migrate the route to `apispec.yml` (ensure OpenAPI 3.0.0 compliance).
+  3. Migrate all referenced schemas (e.g., request/response bodies) to `apispec.yml`.
+  4. Ensure the new route has a default response.
+  5. Use multi-line YAML for any multi-line text fields (see example in this file).
+  6. Run `task generate` to verify the code generator works (no errors).
+  7. Mark the task as complete in this table.
+  8. Update the main [readme](README.md) for supported APIs
+  9. Use github MCP tool to open a new pull request
+
 - Add notes or issues as needed in the Notes column.
 
 ---
@@ -21,7 +25,7 @@ This document tracks the migration of all API routes from `spec/original-spec.js
 | Endpoint                                  | Status | Notes |
 | ----------------------------------------- | :----: | ----- |
 | **/2/sites**                              |  [x]   |       |
-| **/2/sites/{id}**                         |  [ ]   |       |
+| **/2/sites/{id}**                         |  [x]   |       |
 | **/2/shifts**                             |  [x]   |       |
 | **/2/shifts/{id}**                        |  [x]   |       |
 | **/2/shifts/bulk**                        |  [ ]   |       |

--- a/spec/apispec.yml
+++ b/spec/apispec.yml
@@ -438,6 +438,90 @@ paths:
         '404': *not_found_response
         default: *default_response
 
+  /2/sites/{id}:
+    get:
+      summary: Get Site
+      operationId: GetSite
+      description: Get a single site by ID
+      tags:
+        - Sites
+      parameters:
+        - name: id
+          in: path
+          description: The ID of the site
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Valid
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  site:
+                    $ref: '#/components/schemas/Site'
+        '404': *not_found_response
+        default: *default_response
+    put:
+      summary: Update Site
+      operationId: UpdateSite
+      description: Update an existing site
+      tags:
+        - Sites
+      parameters:
+        - name: id
+          in: path
+          description: The ID of the site
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SiteRequest'
+      responses:
+        '200':
+          description: Valid
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  site:
+                    $ref: '#/components/schemas/Site'
+        '404': *not_found_response
+        default: *default_response
+    delete:
+      summary: Delete Site
+      operationId: DeleteSite
+      description: Delete an existing site. This operation cannot be undone.
+      tags:
+        - Sites
+      parameters:
+        - name: id
+          in: path
+          description: The ID of the site
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    description: Whether deletion was successful.
+        '404': *not_found_response
+        default: *default_response
+
   /2/times:
     get:
       summary: List Times


### PR DESCRIPTION
This PR migrates the /2/sites/{id} endpoint to the new OpenAPI 3.0 spec, updates the migration tracker and README to mark it as supported, and ensures all referenced schemas are present. All steps from the migration checklist have been followed, and `task generate` passes with no errors.