### PR TITLE
Migrate /2/shifts/bulk endpoint to OpenAPI 3.0 and mark as supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Package is in active development
 | /2/times/{id}                         | Get, Update, or Delete a single time by ID  |    [x]    |
 | /2/sites                              | List or Create Sites                        |    [x]    |
 | /2/sites/{id}                         | Get, Update, or Delete Site                 |    [x]    |
-| /2/shifts/bulk                        | Bulk Update Shifts                          |    [ ]    |
+| /2/shifts/bulk                        | Bulk Update Shifts                          |    [x]    |
 | /2/shifts/eligible                    | List eligible users for OpenShift           |    [ ]    |
 | /2/shifts/notify                      | Notify shifts                               |    [ ]    |
 | /2/shifts/notify/{id}                 | Notify single shift                         |    [ ]    |

--- a/api-migration-tasks.md
+++ b/api-migration-tasks.md
@@ -14,7 +14,7 @@ This document tracks the migration of all API routes from `spec/original-spec.js
   6. Run `task generate` to verify the code generator works (no errors).
   7. Mark the task as complete in this table.
   8. Update the main [readme](README.md) for supported APIs
-  9. Use github MCP tool to open a new pull request
+  9. Commit all filse using -am, Use github MCP tool to open a new pull request
 
 - Add notes or issues as needed in the Notes column.
 
@@ -28,7 +28,7 @@ This document tracks the migration of all API routes from `spec/original-spec.js
 | **/2/sites/{id}**                         |  [x]   |       |
 | **/2/shifts**                             |  [x]   |       |
 | **/2/shifts/{id}**                        |  [x]   |       |
-| **/2/shifts/bulk**                        |  [ ]   |       |
+| **/2/shifts/bulk**                        |  [x]   |       |
 | **/2/shifts/eligible**                    |  [ ]   |       |
 | **/2/shifts/notify**                      |  [ ]   |       |
 | **/2/shifts/notify/{id}**                 |  [ ]   |       |

--- a/api-migration-tasks.md
+++ b/api-migration-tasks.md
@@ -4,7 +4,7 @@ This document tracks the migration of all API routes from `spec/original-spec.js
 
 **Instructions:**
 
-- Each API route is listed below. For each route:
+- Each API route is listed below. For each route follow these steps DO NO SKIP ANY STEPS:
 
   1. Create a new branch using feat/<apislug>
   2. Migrate the route to `apispec.yml` (ensure OpenAPI 3.0.0 compliance).
@@ -14,7 +14,8 @@ This document tracks the migration of all API routes from `spec/original-spec.js
   6. Run `task generate` to verify the code generator works (no errors).
   7. Mark the task as complete in this table.
   8. Update the main [readme](README.md) for supported APIs
-  9. Commit all filse using -am, Use github MCP tool to open a new pull request
+  9. Commit all filse using -am to make sure to add all changes
+  10. Use github MCP tool to open a new pull request
 
 - Add notes or issues as needed in the Notes column.
 

--- a/spec/apispec.yml
+++ b/spec/apispec.yml
@@ -703,6 +703,44 @@ paths:
         '404': *not_found_response
         default: *default_response
 
+  /2/shifts/bulk:
+    put:
+      summary: Bulk Update Shifts
+      operationId: BulkUpdateShifts
+      description: Make updates to multiple shifts in a single API request by submitting an array of the shifts and data to be changed.
+      tags:
+        - Shifts
+      parameters:
+        - name: assign_openshift_instances
+          in: query
+          description: |
+            When set to true, any multiple instance openshifts that are being assigned will assign only one openshift off the stack rather than the entire stack.
+          required: false
+          schema:
+            type: boolean
+            default: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BulkEditShiftRequest'
+      responses:
+        '200':
+          description: Valid
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  shifts:
+                    description: Array of shift objects to update
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Shift'
+        '404': *not_found_response
+        default: *default_response
+
 components:
   securitySchemes:
     W-Token:
@@ -1446,3 +1484,62 @@ components:
         place_id:
           type: string
           example: '2'
+
+    ShiftBulk:
+      type: object
+      required:
+        - id
+        - start_time
+        - end_time
+        - location_id
+      properties:
+        id:
+          type: integer
+          example: 10000
+        account_id:
+          type: integer
+          example: 10000
+        user_id:
+          type: integer
+          example: 101
+          description: The user assigned to the shift. Set to `0` for an Open Shift.
+        location_id:
+          type: integer
+          example: 1045
+          description: Location the shift belongs to
+        position_id:
+          type: integer
+          example: 19483
+        site_id:
+          type: integer
+          example: 4351
+        start_time:
+          type: string
+          format: date-time
+          example: Mon, 08 May 2023 08:30:00 -0600
+        end_time:
+          type: string
+          format: date-time
+          example: Mon, 08 May 2023 14:30:00 -0600
+        break_time:
+          type: number
+          example: 0.5
+        color:
+          type: string
+          example: cc000
+          description: Assign color to shift
+        notes:
+          type: string
+          example: Shift test
+          description: Text notation for a Shift
+        linked_users:
+          type: array
+          items:
+            type: integer
+          description: Array of user IDs that can take this openshift. Null means all users are eligible.
+
+    BulkEditShiftRequest:
+      description: Array of shift objects to update
+      type: array
+      items:
+        $ref: '#/components/schemas/ShiftBulk'


### PR DESCRIPTION
This PR migrates the /2/shifts/bulk endpoint and its schemas to OpenAPI 3.0.0 in apispec.yml, marks the migration as complete in the tracker, and updates the README to show this endpoint as supported. All steps in the migration checklist have been followed.