### PR TITLE
Migrate /2/shifts/notify/{id} endpoint to OpenAPI 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Package is in active development
 | /2/shifts/bulk                        | Bulk Update Shifts                          |    [x]    |
 | /2/shifts/eligible                    | List eligible users for OpenShift           |    [x]    |
 | /2/shifts/notify                      | Notify shifts                               |    [x]    |
-| /2/shifts/notify/{id}                 | Notify single shift                         |    [ ]    |
+| /2/shifts/notify/{id}                 | Notify single shift                         |    [x]    |
 | /2/shifts/publish                     | Publish Shifts                              |    [ ]    |
 | /2/shifts/unassign                    | Unassign/Release Shifts                     |    [ ]    |
 | /2/shifts/unpublish                   | Unpublish Shifts                            |    [ ]    |

--- a/api-migration-tasks.md
+++ b/api-migration-tasks.md
@@ -32,7 +32,7 @@ This document tracks the migration of all API routes from `spec/original-spec.js
 | **/2/shifts/bulk**                        |  [x]   |       |
 | **/2/shifts/eligible**                    |  [x]   |       |
 | **/2/shifts/notify**                      |  [x]   |       |
-| **/2/shifts/notify/{id}**                 |  [ ]   |       |
+| **/2/shifts/notify/{id}**                 |  [x]   |       |
 | **/2/shifts/publish**                     |  [ ]   |       |
 | **/2/shifts/unassign**                    |  [ ]   |       |
 | **/2/shifts/unpublish**                   |  [ ]   |       |

--- a/spec/apispec.yml
+++ b/spec/apispec.yml
@@ -844,6 +844,54 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /2/shifts/notify/{id}:
+    post:
+      summary: Notify single shift
+      operationId: NotifySingleShift
+      description: |
+        Send Notifications for a single shift.
+        Multi-line YAML is used for this description as per guidelines.
+      tags:
+        - Shifts
+      parameters:
+        - name: id
+          in: path
+          description: The ID of the shift to send notifications
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SingleShiftNotifyRequest'
+      responses:
+        '200':
+          description: Valid
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  email:
+                    type: integer
+                    example: 5
+                    description: A count of the emails sent.
+                  sms:
+                    type: integer
+                    example: 10
+                    description: A count of the SMS and/or push notifications (depending on user preferences) sent.
+        default:
+          description: Default error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
 components:
   securitySchemes:
     W-Token:
@@ -1692,3 +1740,11 @@ components:
             type: integer
             example: 231523
           description: Limit schedule notifications to only shifts tagged to the given user IDs. Defaults to all users.
+
+    SingleShiftNotifyRequest:
+      type: object
+      properties:
+        message:
+          type: string
+          example: hello world
+          description: A custom message to send with the shift notifications.


### PR DESCRIPTION
This PR migrates the /2/shifts/notify/{id} endpoint to the new OpenAPI 3.0 spec, adds the SingleShiftNotifyRequest schema, and marks the migration as complete in the tracker and README.