### PR TITLE
Migrate /2/users/{id} endpoint to apispec.yml

### DIFF
--- a/api-migration-tasks.md
+++ b/api-migration-tasks.md
@@ -40,7 +40,7 @@ This document tracks the migration of all API routes from `spec/original-spec.js
 | **/2/shifts/{id}/history**                |  [x]   |       |
 | **/2/shifts/{id}/swapusers**              |  [x]   |       |
 | **/2/users**                              |  [x]   |       |
-| **/2/users/{id}**                         |  [ ]   |       |
+| **/2/users/{id}**                         |  [x]   |       |
 | **/2/users/avatar/{id}**                  |  [ ]   |       |
 | **/2/users/bulkupdate**                   |  [ ]   |       |
 | **/2/users/invite**                       |  [ ]   |       |


### PR DESCRIPTION
This PR migrates the /2/users/{id} endpoint to the new OpenAPI 3.0.0 spec in apispec.yml, including all referenced schemas and default responses. See api-migration-tasks.md for details.